### PR TITLE
Feature/#41 애플 oauth 연동

### DIFF
--- a/src/main/java/play/pluv/config/RestClientConfig.java
+++ b/src/main/java/play/pluv/config/RestClientConfig.java
@@ -9,6 +9,7 @@ import org.springframework.web.client.RestClient;
 import org.springframework.web.client.RestClient.Builder;
 import org.springframework.web.client.support.RestClientAdapter;
 import org.springframework.web.service.invoker.HttpServiceProxyFactory;
+import play.pluv.oauth.apple.AppleApiClient;
 import play.pluv.oauth.google.GoogleApiClient;
 import play.pluv.oauth.spotify.SpotifyApiClient;
 
@@ -29,6 +30,11 @@ public class RestClientConfig {
   @Bean
   public SpotifyApiClient spotifyApiClient() {
     return createHttpInterface(SpotifyApiClient.class);
+  }
+
+  @Bean
+  public AppleApiClient appleApiClient() {
+    return createHttpInterface(AppleApiClient.class);
   }
 
   @Bean

--- a/src/main/java/play/pluv/login/application/dto/AppleLoginRequest.java
+++ b/src/main/java/play/pluv/login/application/dto/AppleLoginRequest.java
@@ -1,0 +1,7 @@
+package play.pluv.login.application.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record AppleLoginRequest(@NotBlank String idToken) {
+
+}

--- a/src/main/java/play/pluv/login/controller/LoginController.java
+++ b/src/main/java/play/pluv/login/controller/LoginController.java
@@ -1,5 +1,6 @@
 package play.pluv.login.controller;
 
+import static play.pluv.playlist.domain.MusicStreaming.APPLE;
 import static play.pluv.playlist.domain.MusicStreaming.SPOTIFY;
 import static play.pluv.playlist.domain.MusicStreaming.YOUTUBE;
 
@@ -11,6 +12,7 @@ import org.springframework.web.bind.annotation.RestController;
 import play.pluv.base.BaseResponse;
 import play.pluv.login.application.JwtProvider;
 import play.pluv.login.application.LoginService;
+import play.pluv.login.application.dto.AppleLoginRequest;
 import play.pluv.login.application.dto.GoogleLoginRequest;
 import play.pluv.login.application.dto.JwtMemberId;
 import play.pluv.login.application.dto.LoginResponse;
@@ -54,6 +56,23 @@ public class LoginController {
       @Valid @RequestBody final SpotifyLoginRequest loginRequest, final JwtMemberId jwtMemberId
   ) {
     loginService.addOtherLoginWay(SPOTIFY, jwtMemberId.memberId(), loginRequest.accessToken());
+    return BaseResponse.ok("");
+  }
+
+  @PostMapping("/login/apple")
+  public BaseResponse<LoginResponse> loginApple(
+      @Valid @RequestBody final AppleLoginRequest loginRequest
+  ) {
+    final var memberId = loginService.createToken(APPLE, loginRequest.idToken());
+    final var loginResponse = new LoginResponse(jwtProvider.createAccessTokenWith(memberId));
+    return BaseResponse.ok(loginResponse);
+  }
+
+  @PostMapping("/login/apple/add")
+  public BaseResponse<String> addAppleLoginWay(
+      @Valid @RequestBody final AppleLoginRequest loginRequest, final JwtMemberId jwtMemberId
+  ) {
+    loginService.addOtherLoginWay(APPLE, jwtMemberId.memberId(), loginRequest.idToken());
     return BaseResponse.ok("");
   }
 }

--- a/src/main/java/play/pluv/login/exception/LoginExceptionType.java
+++ b/src/main/java/play/pluv/login/exception/LoginExceptionType.java
@@ -1,6 +1,7 @@
 package play.pluv.login.exception;
 
 import static org.springframework.http.HttpStatus.BAD_REQUEST;
+import static org.springframework.http.HttpStatus.INTERNAL_SERVER_ERROR;
 import static org.springframework.http.HttpStatus.NOT_FOUND;
 import static org.springframework.http.HttpStatus.UNAUTHORIZED;
 
@@ -15,6 +16,7 @@ public enum LoginExceptionType implements BaseExceptionType {
 
   PLAYLIST_PROVIDER_NOT_FOUND(NOT_FOUND, "지원하지 않는 스트리밍 서비스입니다"),
   INVALID_ACCESS_TOKEN(UNAUTHORIZED, "토큰이 유효하지 않습니다."),
+  GENERATE_APPLE_CLIENT_SECRET_ERROR(INTERNAL_SERVER_ERROR, "private key를 만드는데 오류가 발생했습니다."),
   NOT_FOUND_AUTHORIZATION_TOKEN(BAD_REQUEST, "인증 토큰을 찾을 수 없습니다."),
   INVALID_ACCESS_TOKEN_TYPE(BAD_REQUEST, "Access Token Type이 올바르지 않습니다.");
 

--- a/src/main/java/play/pluv/oauth/apple/AppleApiClient.java
+++ b/src/main/java/play/pluv/oauth/apple/AppleApiClient.java
@@ -1,0 +1,14 @@
+package play.pluv.oauth.apple;
+
+import static org.springframework.http.MediaType.APPLICATION_FORM_URLENCODED_VALUE;
+
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.service.annotation.PostExchange;
+import play.pluv.oauth.apple.dto.AppleTokenResponse;
+
+public interface AppleApiClient {
+
+  @PostExchange(url = "https://appleid.apple.com/auth/oauth2/v2/token", contentType = APPLICATION_FORM_URLENCODED_VALUE)
+  AppleTokenResponse fetchToken(@RequestParam final MultiValueMap<String, String> params);
+}

--- a/src/main/java/play/pluv/oauth/apple/AppleConfigProperty.java
+++ b/src/main/java/play/pluv/oauth/apple/AppleConfigProperty.java
@@ -1,0 +1,14 @@
+package play.pluv.oauth.apple;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "apple")
+public record AppleConfigProperty(
+    String keyId,
+    String teamId,
+    String clientId,
+    String redirectUri,
+    String privateKey
+) {
+
+}

--- a/src/main/java/play/pluv/oauth/apple/AppleConnector.java
+++ b/src/main/java/play/pluv/oauth/apple/AppleConnector.java
@@ -1,19 +1,25 @@
 package play.pluv.oauth.apple;
 
-import static io.jsonwebtoken.io.Decoders.BASE64;
 import static java.lang.System.currentTimeMillis;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static java.util.concurrent.TimeUnit.MINUTES;
+import static play.pluv.login.exception.LoginExceptionType.GENERATE_APPLE_CLIENT_SECRET_ERROR;
 import static play.pluv.playlist.domain.MusicStreaming.APPLE;
 
 import io.jsonwebtoken.Jwts;
-import io.jsonwebtoken.security.Keys;
+import java.security.KeyFactory;
+import java.security.NoSuchAlgorithmException;
+import java.security.interfaces.ECPrivateKey;
+import java.security.spec.InvalidKeySpecException;
+import java.security.spec.PKCS8EncodedKeySpec;
+import java.util.Base64;
 import java.util.Date;
 import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
+import play.pluv.login.exception.LoginException;
 import play.pluv.oauth.apple.dto.AppleTokenResponse;
 import play.pluv.oauth.application.SocialLoginClient;
 import play.pluv.oauth.domain.OAuthMemberInfo;
@@ -31,12 +37,11 @@ public class AppleConnector implements SocialLoginClient {
 
   @Override
   public OAuthMemberInfo fetchMember(final String authCode) {
-    final MultiValueMap<String, String> param = createRequestParamForAccessToken(authCode);
-    final AppleTokenResponse appleTokenResponse = appleApiClient.fetchToken(param);
+    final AppleTokenResponse appleToken = geTokens(authCode);
     return null;
   }
 
-  public AppleTokenResponse fetchMemberTest(final String authCode) {
+  public AppleTokenResponse geTokens(final String authCode) {
     final MultiValueMap<String, String> param = createRequestParamForAccessToken(authCode);
     return appleApiClient.fetchToken(param);
   }
@@ -56,25 +61,6 @@ public class AppleConnector implements SocialLoginClient {
     return param;
   }
 
-  //  @Override
-//  public OAuth2MemberResponse getMemberResponse(String authCode) {
-//    AppleTokenResponse tokenResponse;
-//    try {
-//      tokenResponse = appleOAuth2Client.getToken(
-//          appleOAuth2Properties.getClientId(),
-//          generateClientSecret(),
-//          GRANT_TYPE,
-//          authCode
-//      );
-//    } catch (Exception e) {
-//      throw new BaseException(AppleExceptionType.TOKEN_ERROR, e);
-//    }
-//    String idToken = tokenResponse.getIdToken();
-//    AppleTokenIdPayload appleTokenIdPayload = jwtProvider.decodePayload(idToken,
-//        AppleTokenIdPayload.class);
-//    return new AppleOAuth2MemberResponse(appleTokenIdPayload.getEmail());
-//  }
-//
   private String generateClientSecret() {
     final Map<String, Object> jwtHeaders = Map.of(
         "kid", appleConfigProperty.keyId(),
@@ -88,20 +74,18 @@ public class AppleConnector implements SocialLoginClient {
         .audience().add(AUDIENCE).and()
         .expiration(new Date(EXP + currentTimeMillis()))
         .subject(appleConfigProperty.clientId())
-        .signWith(Keys.hmacShaKeyFor(BASE64.decode(appleConfigProperty.privateKey())))
+        .signWith(getPrivateKeyFromPem(appleConfigProperty.privateKey()))
         .compact();
   }
 
-//  private PrivateKey generatePrivateKey() {
-//    Security.addProvider(new BouncyCastleProvider());
-//    JcaPEMKeyConverter converter = new JcaPEMKeyConverter().setProvider("BC");
-//
-//    try {
-//      byte[] privateKeyBytes = Base64.getDecoder().decode(appleOAuth2Properties.getPrivateKey());
-//
-//      return converter.getPrivateKey(PrivateKeyInfo.getInstance(privateKeyBytes));
-//    } catch (Exception e) {
-//      throw new RuntimeException("애플에 전송시 사용할 키 생성 중 예외가 발생했습니다.", e);
-//    }
-//  }
+  private static ECPrivateKey getPrivateKeyFromPem(final String privateKey) {
+    try {
+      final byte[] decoded = Base64.getDecoder().decode(privateKey);
+      final PKCS8EncodedKeySpec keySpec = new PKCS8EncodedKeySpec(decoded);
+      final KeyFactory keyFactory = KeyFactory.getInstance("EC");
+      return (ECPrivateKey) keyFactory.generatePrivate(keySpec);
+    } catch (final NoSuchAlgorithmException | InvalidKeySpecException e) {
+      throw new LoginException(GENERATE_APPLE_CLIENT_SECRET_ERROR);
+    }
+  }
 }

--- a/src/main/java/play/pluv/oauth/apple/AppleConnector.java
+++ b/src/main/java/play/pluv/oauth/apple/AppleConnector.java
@@ -1,0 +1,107 @@
+package play.pluv.oauth.apple;
+
+import static io.jsonwebtoken.io.Decoders.BASE64;
+import static java.lang.System.currentTimeMillis;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static java.util.concurrent.TimeUnit.MINUTES;
+import static play.pluv.playlist.domain.MusicStreaming.APPLE;
+
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.security.Keys;
+import java.util.Date;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import play.pluv.oauth.apple.dto.AppleTokenResponse;
+import play.pluv.oauth.application.SocialLoginClient;
+import play.pluv.oauth.domain.OAuthMemberInfo;
+import play.pluv.playlist.domain.MusicStreaming;
+
+@Component
+@RequiredArgsConstructor
+public class AppleConnector implements SocialLoginClient {
+
+  private static final String AUDIENCE = "https://appleid.apple.com";
+  private static final Long EXP = MILLISECONDS.convert(30, MINUTES);
+
+  private final AppleApiClient appleApiClient;
+  private final AppleConfigProperty appleConfigProperty;
+
+  @Override
+  public OAuthMemberInfo fetchMember(final String authCode) {
+    final MultiValueMap<String, String> param = createRequestParamForAccessToken(authCode);
+    final AppleTokenResponse appleTokenResponse = appleApiClient.fetchToken(param);
+    return null;
+  }
+
+  public AppleTokenResponse fetchMemberTest(final String authCode) {
+    final MultiValueMap<String, String> param = createRequestParamForAccessToken(authCode);
+    return appleApiClient.fetchToken(param);
+  }
+
+  @Override
+  public MusicStreaming supportedType() {
+    return APPLE;
+  }
+
+  private MultiValueMap<String, String> createRequestParamForAccessToken(final String authCode) {
+    final MultiValueMap<String, String> param = new LinkedMultiValueMap<>();
+    param.add("grant_type", "authorization_code");
+    param.add("code", authCode);
+    param.add("redirect_uri", appleConfigProperty.redirectUri());
+    param.add("client_id", appleConfigProperty.clientId());
+    param.add("client_secret", generateClientSecret());
+    return param;
+  }
+
+  //  @Override
+//  public OAuth2MemberResponse getMemberResponse(String authCode) {
+//    AppleTokenResponse tokenResponse;
+//    try {
+//      tokenResponse = appleOAuth2Client.getToken(
+//          appleOAuth2Properties.getClientId(),
+//          generateClientSecret(),
+//          GRANT_TYPE,
+//          authCode
+//      );
+//    } catch (Exception e) {
+//      throw new BaseException(AppleExceptionType.TOKEN_ERROR, e);
+//    }
+//    String idToken = tokenResponse.getIdToken();
+//    AppleTokenIdPayload appleTokenIdPayload = jwtProvider.decodePayload(idToken,
+//        AppleTokenIdPayload.class);
+//    return new AppleOAuth2MemberResponse(appleTokenIdPayload.getEmail());
+//  }
+//
+  private String generateClientSecret() {
+    final Map<String, Object> jwtHeaders = Map.of(
+        "kid", appleConfigProperty.keyId(),
+        "alg", "ES256"
+    );
+
+    return Jwts.builder()
+        .header().add(jwtHeaders).and()
+        .issuer(appleConfigProperty.teamId())
+        .issuedAt(new Date())
+        .audience().add(AUDIENCE).and()
+        .expiration(new Date(EXP + currentTimeMillis()))
+        .subject(appleConfigProperty.clientId())
+        .signWith(Keys.hmacShaKeyFor(BASE64.decode(appleConfigProperty.privateKey())))
+        .compact();
+  }
+
+//  private PrivateKey generatePrivateKey() {
+//    Security.addProvider(new BouncyCastleProvider());
+//    JcaPEMKeyConverter converter = new JcaPEMKeyConverter().setProvider("BC");
+//
+//    try {
+//      byte[] privateKeyBytes = Base64.getDecoder().decode(appleOAuth2Properties.getPrivateKey());
+//
+//      return converter.getPrivateKey(PrivateKeyInfo.getInstance(privateKeyBytes));
+//    } catch (Exception e) {
+//      throw new RuntimeException("애플에 전송시 사용할 키 생성 중 예외가 발생했습니다.", e);
+//    }
+//  }
+}

--- a/src/main/java/play/pluv/oauth/apple/dto/AppleTokenResponse.java
+++ b/src/main/java/play/pluv/oauth/apple/dto/AppleTokenResponse.java
@@ -1,0 +1,12 @@
+package play.pluv.oauth.apple.dto;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+
+@JsonNaming(SnakeCaseStrategy.class)
+public record AppleTokenResponse(
+    String accessToken,
+    String idToken
+) {
+
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -21,6 +21,12 @@ google:
   client-id: local-id
   client-secret: local-secret
   redirectUri: http://localhost:8080
+apple:
+  key-id: local
+  client-id: local
+  private-key: local
+  redirect-uri: local
+  team-id: local
 restClient:
   logging: true
 jwt:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -38,3 +38,10 @@ spring:
     import: classpath:secret/application-prod.yml
     activate:
       on-profile: prod
+
+---
+spring:
+  config:
+    import: classpath:secret/application-dev.yml
+    activate:
+      on-profile: dev

--- a/src/test/java/play/pluv/api/LoginApiTest.java
+++ b/src/test/java/play/pluv/api/LoginApiTest.java
@@ -4,6 +4,8 @@ import static com.epages.restdocs.apispec.MockMvcRestDocumentationWrapper.docume
 import static org.mockito.Mockito.when;
 import static org.springframework.http.HttpHeaders.AUTHORIZATION;
 import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
+import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
+import static org.springframework.restdocs.headers.HeaderDocumentation.requestHeaders;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
 import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessRequest;
 import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessResponse;
@@ -120,6 +122,9 @@ public class LoginApiTest extends ApiTest {
         .andDo(document("google-login-add",
             preprocessRequest(prettyPrint()),
             preprocessResponse(prettyPrint()),
+            requestHeaders(
+                headerWithName(AUTHORIZATION).description("Bearer Token")
+            ),
             requestFields(
                 fieldWithPath("idToken").type(STRING).description("구글의 idToken")
             ),
@@ -148,6 +153,9 @@ public class LoginApiTest extends ApiTest {
         .andDo(document("spotify-login-add",
             preprocessRequest(prettyPrint()),
             preprocessResponse(prettyPrint()),
+            requestHeaders(
+                headerWithName(AUTHORIZATION).description("Bearer Token")
+            ),
             requestFields(
                 fieldWithPath("accessToken").type(STRING).description("스포티파이의 accessToken")
             ),
@@ -176,6 +184,9 @@ public class LoginApiTest extends ApiTest {
         .andDo(document("apple-login-add",
             preprocessRequest(prettyPrint()),
             preprocessResponse(prettyPrint()),
+            requestHeaders(
+                headerWithName(AUTHORIZATION).description("Bearer Token")
+            ),
             requestFields(
                 fieldWithPath("idToken").type(STRING).description("apple의 idToken")
             ),

--- a/src/test/java/play/pluv/api/LoginApiTest.java
+++ b/src/test/java/play/pluv/api/LoginApiTest.java
@@ -14,10 +14,12 @@ import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWit
 import static org.springframework.restdocs.payload.PayloadDocumentation.requestFields;
 import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static play.pluv.playlist.domain.MusicStreaming.APPLE;
 import static play.pluv.playlist.domain.MusicStreaming.SPOTIFY;
 import static play.pluv.playlist.domain.MusicStreaming.YOUTUBE;
 
 import org.junit.jupiter.api.Test;
+import play.pluv.login.application.dto.AppleLoginRequest;
 import play.pluv.login.application.dto.GoogleLoginRequest;
 import play.pluv.login.application.dto.SpotifyLoginRequest;
 import play.pluv.support.ApiTest;
@@ -77,6 +79,31 @@ public class LoginApiTest extends ApiTest {
   }
 
   @Test
+  void 애플_소셜_로그인을_한다() throws Exception {
+    final AppleLoginRequest loginRequest = new AppleLoginRequest("idToken");
+
+    final String requestBody = objectMapper.writeValueAsString(loginRequest);
+
+    when(loginService.createToken(APPLE, "idToken")).thenReturn(2L);
+    setCreateToken("idToken", 2L);
+
+    mockMvc.perform(post("/login/apple")
+            .contentType(APPLICATION_JSON_VALUE)
+            .content(requestBody))
+        .andExpect(status().isOk())
+        .andDo(document("apple-login",
+            requestFields(
+                fieldWithPath("idToken").type(STRING).description("스포티파이의 accessToken")
+            ),
+            responseFields(
+                fieldWithPath("code").type(NUMBER).description("상태 코드"),
+                fieldWithPath("msg").type(STRING).description("상태 코드에 해당하는 메시지"),
+                fieldWithPath("data.token").type(STRING).description("로그인 할 떄 쓸 accessToken")
+            )
+        ));
+  }
+
+  @Test
   void 구글_소셜_로그인_방법을_추가한다() throws Exception {
     final Long memberId = 10L;
     final String token = "access Token";
@@ -94,7 +121,7 @@ public class LoginApiTest extends ApiTest {
             preprocessRequest(prettyPrint()),
             preprocessResponse(prettyPrint()),
             requestFields(
-                fieldWithPath("idToken").type(STRING).description("구글의 accessToken")
+                fieldWithPath("idToken").type(STRING).description("구글의 idToken")
             ),
             responseFields(
                 fieldWithPath("code").type(NUMBER).description("상태 코드"),
@@ -123,6 +150,34 @@ public class LoginApiTest extends ApiTest {
             preprocessResponse(prettyPrint()),
             requestFields(
                 fieldWithPath("accessToken").type(STRING).description("스포티파이의 accessToken")
+            ),
+            responseFields(
+                fieldWithPath("code").type(NUMBER).description("상태 코드"),
+                fieldWithPath("msg").type(STRING).description("상태 코드에 해당하는 메시지"),
+                fieldWithPath("data").type(STRING).description("")
+            )
+        ));
+  }
+
+  @Test
+  void 애플_소셜_로그인_방법을_추가한다() throws Exception {
+    final String token = "access Token";
+    final Long memberId = 10L;
+    final AppleLoginRequest loginRequest = new AppleLoginRequest("idToken");
+
+    final String requestBody = objectMapper.writeValueAsString(loginRequest);
+    setAccessToken(token, memberId);
+
+    mockMvc.perform(post("/login/apple/add")
+            .contentType(APPLICATION_JSON_VALUE)
+            .content(requestBody)
+            .header(AUTHORIZATION, "Bearer " + token))
+        .andExpect(status().isOk())
+        .andDo(document("apple-login-add",
+            preprocessRequest(prettyPrint()),
+            preprocessResponse(prettyPrint()),
+            requestFields(
+                fieldWithPath("idToken").type(STRING).description("apple의 idToken")
             ),
             responseFields(
                 fieldWithPath("code").type(NUMBER).description("상태 코드"),

--- a/src/test/java/play/pluv/api/MemberApiTest.java
+++ b/src/test/java/play/pluv/api/MemberApiTest.java
@@ -4,6 +4,8 @@ import static com.epages.restdocs.apispec.MockMvcRestDocumentationWrapper.docume
 import static org.mockito.Mockito.verify;
 import static org.springframework.http.HttpHeaders.AUTHORIZATION;
 import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
+import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
+import static org.springframework.restdocs.headers.HeaderDocumentation.requestHeaders;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
 import static org.springframework.restdocs.payload.JsonFieldType.NUMBER;
 import static org.springframework.restdocs.payload.JsonFieldType.STRING;
@@ -35,6 +37,9 @@ public class MemberApiTest extends ApiTest {
             .header(AUTHORIZATION, "Bearer " + token))
         .andExpect(status().isOk())
         .andDo(document("update-nickname",
+            requestHeaders(
+                headerWithName(AUTHORIZATION).description("Bearer Token")
+            ),
             requestFields(
                 fieldWithPath("nickName").type(STRING).description("변경할 새로운 닉네임")
             ),
@@ -58,6 +63,9 @@ public class MemberApiTest extends ApiTest {
             .header(AUTHORIZATION, "Bearer " + token))
         .andExpect(status().isOk())
         .andDo(document("unregister",
+            requestHeaders(
+                headerWithName(AUTHORIZATION).description("Bearer Token")
+            ),
             responseFields(
                 fieldWithPath("code").type(NUMBER).description("상태 코드"),
                 fieldWithPath("msg").type(STRING).description("상태 코드에 해당하는 메시지"),


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- close : #41 

## 📝 작업 내용

- 애플 Oauth 연동
- 애플 login api 추가
- 애플 login 방법 추가 api 추가

## 예상 소요 시간 및 실제 소요 시간 (일 / 시간 / 분)

예상 소요 시간 : 4시간
실제 소요 시간 : 10시간
