### PR TITLE
feat: 히스토리를 만들 때 피드를 생성하는 기능 추가(#51)

### DIFF
--- a/src/main/java/play/pluv/feed/domain/Feed.java
+++ b/src/main/java/play/pluv/feed/domain/Feed.java
@@ -1,0 +1,40 @@
+package play.pluv.feed.domain;
+
+import static jakarta.persistence.GenerationType.IDENTITY;
+import static lombok.AccessLevel.PROTECTED;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import lombok.Builder;
+import lombok.NoArgsConstructor;
+import play.pluv.base.BaseEntity;
+
+@Entity
+@NoArgsConstructor(access = PROTECTED)
+public class Feed extends BaseEntity {
+
+  @Id
+  @GeneratedValue(strategy = IDENTITY)
+  private Long id;
+  private Long historyId;
+  private Long memberId;
+  private String title;
+  private String creatorName;
+  private String artistNames;
+  private String thumbNailUrl;
+  private Boolean viewable;
+
+  @Builder
+  public Feed(final Long historyId, final Long memberId, final String title,
+      final String creatorName, final String artistNames,
+      final String thumbNailUrl, final Boolean viewable) {
+    this.historyId = historyId;
+    this.memberId = memberId;
+    this.title = title;
+    this.creatorName = creatorName;
+    this.artistNames = artistNames;
+    this.thumbNailUrl = thumbNailUrl;
+    this.viewable = viewable;
+  }
+}

--- a/src/main/java/play/pluv/feed/domain/repository/FeedRepository.java
+++ b/src/main/java/play/pluv/feed/domain/repository/FeedRepository.java
@@ -1,0 +1,10 @@
+package play.pluv.feed.domain.repository;
+
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+import play.pluv.feed.domain.Feed;
+
+public interface FeedRepository extends JpaRepository<Feed, Long> {
+
+  Optional<Feed> findByHistoryId(final Long historyId);
+}

--- a/src/main/java/play/pluv/history/domain/History.java
+++ b/src/main/java/play/pluv/history/domain/History.java
@@ -1,6 +1,7 @@
 package play.pluv.history.domain;
 
 import static jakarta.persistence.GenerationType.IDENTITY;
+import static java.util.stream.Collectors.joining;
 import static lombok.AccessLevel.PROTECTED;
 import static play.pluv.history.exception.HistoryExceptionType.HISTORY_NOT_OWNER;
 
@@ -10,11 +11,13 @@ import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.Id;
 import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Objects;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import play.pluv.base.BaseEntity;
+import play.pluv.feed.domain.Feed;
 import play.pluv.history.exception.HistoryException;
 import play.pluv.playlist.domain.MusicStreaming;
 
@@ -69,5 +72,27 @@ public class History extends BaseEntity {
     if (!Objects.equals(memberId, this.memberId)) {
       throw new HistoryException(HISTORY_NOT_OWNER);
     }
+  }
+
+  public Feed createFeed(
+      final String creatorName, final List<TransferredMusic> transferredMusics
+  ) {
+    final String artistNames = extractArtistNames(transferredMusics);
+
+    return Feed.builder()
+        .viewable(true)
+        .historyId(id)
+        .memberId(memberId)
+        .title(title)
+        .creatorName(creatorName)
+        .artistNames(artistNames)
+        .thumbNailUrl(thumbNailUrl)
+        .build();
+  }
+
+  private String extractArtistNames(final List<TransferredMusic> transferredMusics) {
+    return transferredMusics.stream()
+        .map(TransferredMusic::getArtistNames)
+        .collect(joining(","));
   }
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- close : #51 

## 📝 작업 내용

- 히스토리를 만들 때 피드를 생성하는 기능 추가

## 예상 소요 시간 및 실제 소요 시간 (일 / 시간 / 분)

예상 소요 시간 : 2시간
실제 소요 시간 : 1시간
