### PR TITLE
Feature/#108 피드에 이전 음악정보 추가

### DIFF
--- a/src/main/java/play/pluv/feed/application/FeedReader.java
+++ b/src/main/java/play/pluv/feed/application/FeedReader.java
@@ -31,4 +31,12 @@ public class FeedReader {
         .map(FeedBookmark::getFeed)
         .toList();
   }
+
+  public Feed findFeed(final Long feedId) {
+    return feedRepository.readById(feedId);
+  }
+
+  public Boolean isBookMarked(final Feed feed, final Long memberId) {
+    return feedBookmarkRepository.existsByMemberIdAndFeed(memberId, feed);
+  }
 }

--- a/src/main/java/play/pluv/feed/application/FeedService.java
+++ b/src/main/java/play/pluv/feed/application/FeedService.java
@@ -4,6 +4,7 @@ import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import play.pluv.feed.application.dto.FeedDetailResponse;
 import play.pluv.feed.domain.Feed;
 import play.pluv.member.application.MemberReader;
 import play.pluv.member.domain.Member;
@@ -31,5 +32,12 @@ public class FeedService {
   public List<Feed> findBookmarkedFeeds(final Long memberId) {
     final Member member = memberReader.readById(memberId);
     return feedReader.findBookmarkedFeeds(member);
+  }
+
+  @Transactional(readOnly = true)
+  public FeedDetailResponse findFeed(final Long id, final Long memberId) {
+    final Feed feed = feedReader.findFeed(id);
+    final Boolean isBookmarked = feedReader.isBookMarked(feed, memberId);
+    return FeedDetailResponse.from(feed, isBookmarked);
   }
 }

--- a/src/main/java/play/pluv/feed/application/dto/FeedDetailResponse.java
+++ b/src/main/java/play/pluv/feed/application/dto/FeedDetailResponse.java
@@ -1,0 +1,22 @@
+package play.pluv.feed.application.dto;
+
+import java.time.LocalDate;
+import play.pluv.feed.domain.Feed;
+
+public record FeedDetailResponse(
+    Long id,
+    Integer songCount,
+    String title,
+    String imageUrl,
+    String creatorName,
+    Boolean isBookMarked,
+    LocalDate createdAt
+) {
+
+  public static FeedDetailResponse from(final Feed feed, final Boolean isBookMarked) {
+    return new FeedDetailResponse(
+        feed.getId(), feed.getSongCount(), feed.getTitle(), feed.getThumbNailUrl(),
+        feed.getCreatorName(), isBookMarked, feed.getCreatedAt().toLocalDate()
+    );
+  }
+}

--- a/src/main/java/play/pluv/feed/controller/FeedController.java
+++ b/src/main/java/play/pluv/feed/controller/FeedController.java
@@ -9,6 +9,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import play.pluv.base.BaseResponse;
 import play.pluv.feed.application.FeedService;
+import play.pluv.feed.application.dto.FeedDetailResponse;
 import play.pluv.feed.application.dto.FeedListResponse;
 import play.pluv.security.JwtMemberId;
 
@@ -24,6 +25,14 @@ public class FeedController {
     final var feeds = feedService.findAll();
     final List<FeedListResponse> responses = FeedListResponse.createList(feeds);
     return BaseResponse.ok(responses);
+  }
+
+  @GetMapping("/{id}")
+  public BaseResponse<FeedDetailResponse> getFeed(
+      @PathVariable final Long id, final JwtMemberId jwtMemberIdq
+  ) {
+    final FeedDetailResponse feedResponse = feedService.findFeed(id, jwtMemberIdq.memberId());
+    return BaseResponse.ok(feedResponse);
   }
 
   @PostMapping("/{id}/save")

--- a/src/main/java/play/pluv/feed/domain/Feed.java
+++ b/src/main/java/play/pluv/feed/domain/Feed.java
@@ -28,11 +28,12 @@ public class Feed extends BaseEntity {
   private String artistNames;
   private String thumbNailUrl;
   private Boolean viewable;
+  private Integer songCount;
 
   @Builder
   public Feed(final Long memberId, final String title,
       final String creatorName, final String artistNames,
-      final String thumbNailUrl) {
+      final String thumbNailUrl, final Integer songCount) {
     this.memberId = memberId;
     this.title = title;
     this.creatorName = creatorName;
@@ -41,11 +42,12 @@ public class Feed extends BaseEntity {
     this.viewable = true;
     this.createdAt = LocalDateTime.now();
     this.updatedAt = LocalDateTime.now();
+    this.songCount = songCount;
   }
 
   public Feed(
-      final Long id, final Long memberId, final String title,
-      final String creatorName, final String artistNames, final String thumbNailUrl
+      final Long id, final Long memberId, final String title, final String creatorName,
+      final String artistNames, final String thumbNailUrl, final Integer songCount
   ) {
     this.id = id;
     this.memberId = memberId;
@@ -54,6 +56,7 @@ public class Feed extends BaseEntity {
     this.artistNames = artistNames;
     this.thumbNailUrl = thumbNailUrl;
     this.viewable = true;
+    this.songCount = songCount;
     this.createdAt = LocalDateTime.now();
     this.updatedAt = LocalDateTime.now();
   }

--- a/src/main/java/play/pluv/feed/domain/Feed.java
+++ b/src/main/java/play/pluv/feed/domain/Feed.java
@@ -32,13 +32,13 @@ public class Feed extends BaseEntity {
   @Builder
   public Feed(final Long memberId, final String title,
       final String creatorName, final String artistNames,
-      final String thumbNailUrl, final Boolean viewable) {
+      final String thumbNailUrl) {
     this.memberId = memberId;
     this.title = title;
     this.creatorName = creatorName;
     this.artistNames = artistNames;
     this.thumbNailUrl = thumbNailUrl;
-    this.viewable = viewable;
+    this.viewable = true;
     this.createdAt = LocalDateTime.now();
     this.updatedAt = LocalDateTime.now();
   }

--- a/src/main/java/play/pluv/feed/domain/Feed.java
+++ b/src/main/java/play/pluv/feed/domain/Feed.java
@@ -22,7 +22,6 @@ public class Feed extends BaseEntity {
   @Id
   @GeneratedValue(strategy = IDENTITY)
   private Long id;
-  private Long historyId;
   private Long memberId;
   private String title;
   private String creatorName;
@@ -31,10 +30,9 @@ public class Feed extends BaseEntity {
   private Boolean viewable;
 
   @Builder
-  public Feed(final Long historyId, final Long memberId, final String title,
+  public Feed(final Long memberId, final String title,
       final String creatorName, final String artistNames,
       final String thumbNailUrl, final Boolean viewable) {
-    this.historyId = historyId;
     this.memberId = memberId;
     this.title = title;
     this.creatorName = creatorName;
@@ -46,11 +44,10 @@ public class Feed extends BaseEntity {
   }
 
   public Feed(
-      final Long id, final Long historyId, final Long memberId, final String title,
+      final Long id, final Long memberId, final String title,
       final String creatorName, final String artistNames, final String thumbNailUrl
   ) {
     this.id = id;
-    this.historyId = historyId;
     this.memberId = memberId;
     this.title = title;
     this.creatorName = creatorName;

--- a/src/main/java/play/pluv/feed/domain/repository/FeedBookmarkRepository.java
+++ b/src/main/java/play/pluv/feed/domain/repository/FeedBookmarkRepository.java
@@ -3,6 +3,7 @@ package play.pluv.feed.domain.repository;
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import play.pluv.feed.domain.Feed;
 import play.pluv.feed.domain.FeedBookmark;
 
 public interface FeedBookmarkRepository extends JpaRepository<FeedBookmark, Long> {
@@ -14,4 +15,6 @@ public interface FeedBookmarkRepository extends JpaRepository<FeedBookmark, Long
       where fb.memberId = :memberId
       """)
   List<FeedBookmark> findByMemberIdWithJoin(final Long memberId);
+
+  Boolean existsByMemberIdAndFeed(final Long memberId, final Feed feed);
 }

--- a/src/main/java/play/pluv/feed/domain/repository/FeedRepository.java
+++ b/src/main/java/play/pluv/feed/domain/repository/FeedRepository.java
@@ -2,14 +2,11 @@ package play.pluv.feed.domain.repository;
 
 import static play.pluv.feed.exception.FeedExceptionType.FEED_NOT_FOUND;
 
-import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import play.pluv.feed.domain.Feed;
 import play.pluv.feed.exception.FeedException;
 
 public interface FeedRepository extends JpaRepository<Feed, Long> {
-
-  Optional<Feed> findByHistoryId(final Long historyId);
 
   default Feed readById(final Long id) {
     return findById(id).orElseThrow(() -> new FeedException(FEED_NOT_FOUND));

--- a/src/main/java/play/pluv/history/application/HistoryReader.java
+++ b/src/main/java/play/pluv/history/application/HistoryReader.java
@@ -35,4 +35,9 @@ public class HistoryReader {
   public List<TransferFailMusic> readTransferFailMusics(final Long historyId) {
     return transferFailMusicRepository.findByHistoryId(historyId);
   }
+
+  public List<TransferredMusic> readFeedMusics(final Long feedId) {
+    final History history = historyRepository.readByFeedId(feedId);
+    return transferredMusicRepository.findByHistoryId(history.getId());
+  }
 }

--- a/src/main/java/play/pluv/history/application/HistoryService.java
+++ b/src/main/java/play/pluv/history/application/HistoryService.java
@@ -36,6 +36,7 @@ public class HistoryService {
     return historyReader.readTransferredMusics(historyId);
   }
 
+  @Transactional(readOnly = true)
   public List<TransferredMusic> findFeedMusics(final Long feedId) {
     return historyReader.readFeedMusics(feedId);
   }

--- a/src/main/java/play/pluv/history/application/HistoryService.java
+++ b/src/main/java/play/pluv/history/application/HistoryService.java
@@ -35,4 +35,8 @@ public class HistoryService {
   public List<TransferredMusic> findTransferredMusics(final Long historyId, final Long memberId) {
     return historyReader.readTransferredMusics(historyId);
   }
+
+  public List<TransferredMusic> findFeedMusics(final Long feedId) {
+    return historyReader.readFeedMusics(feedId);
+  }
 }

--- a/src/main/java/play/pluv/history/application/dto/MusicResponse.java
+++ b/src/main/java/play/pluv/history/application/dto/MusicResponse.java
@@ -4,39 +4,39 @@ import java.util.List;
 import play.pluv.history.domain.TransferFailMusic;
 import play.pluv.history.domain.TransferredMusic;
 
-public record HistoryMusicResponse(
+public record MusicResponse(
     String title,
     String imageUrl,
     String artistNames
 ) {
 
-  public static HistoryMusicResponse from(final TransferredMusic transferredMusic) {
-    return new HistoryMusicResponse(
+  public static MusicResponse from(final TransferredMusic transferredMusic) {
+    return new MusicResponse(
         transferredMusic.getTitle(), transferredMusic.getImageUrl(),
         transferredMusic.getArtistNames()
     );
   }
 
-  public static HistoryMusicResponse from(final TransferFailMusic transferFailMusic) {
-    return new HistoryMusicResponse(
+  public static MusicResponse from(final TransferFailMusic transferFailMusic) {
+    return new MusicResponse(
         transferFailMusic.getTitle(), transferFailMusic.getImageUrl(),
         transferFailMusic.getArtistNames()
     );
   }
 
-  public static List<HistoryMusicResponse> createListFromTransferFail(
+  public static List<MusicResponse> createListFromTransferFail(
       final List<TransferFailMusic> transferFailMusics
   ) {
     return transferFailMusics.stream()
-        .map(HistoryMusicResponse::from)
+        .map(MusicResponse::from)
         .toList();
   }
 
-  public static List<HistoryMusicResponse> createListFromTransferred(
+  public static List<MusicResponse> createListFromTransferred(
       final List<TransferredMusic> transferredMusics
   ) {
     return transferredMusics.stream()
-        .map(HistoryMusicResponse::from)
+        .map(MusicResponse::from)
         .toList();
   }
 }

--- a/src/main/java/play/pluv/history/controller/FeedHistoryController.java
+++ b/src/main/java/play/pluv/history/controller/FeedHistoryController.java
@@ -1,0 +1,28 @@
+package play.pluv.history.controller;
+
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import play.pluv.base.BaseResponse;
+import play.pluv.history.application.HistoryService;
+import play.pluv.history.application.dto.MusicResponse;
+import play.pluv.history.domain.TransferredMusic;
+
+@RequestMapping("/feed")
+@RequiredArgsConstructor
+@RestController
+public class FeedHistoryController {
+
+  private final HistoryService historyService;
+
+  @GetMapping("/{id}/music")
+  public BaseResponse<List<MusicResponse>> getFeedMusics(@PathVariable final Long id) {
+    final List<TransferredMusic> transferredMusics = historyService.findFeedMusics(id);
+    final List<MusicResponse> responses = MusicResponse
+        .createListFromTransferred(transferredMusics);
+    return BaseResponse.ok(responses);
+  }
+}

--- a/src/main/java/play/pluv/history/controller/HistoryController.java
+++ b/src/main/java/play/pluv/history/controller/HistoryController.java
@@ -9,7 +9,7 @@ import play.pluv.base.BaseResponse;
 import play.pluv.history.application.HistoryService;
 import play.pluv.history.application.dto.HistoryDetailResponse;
 import play.pluv.history.application.dto.HistoryListResponse;
-import play.pluv.history.application.dto.HistoryMusicResponse;
+import play.pluv.history.application.dto.MusicResponse;
 import play.pluv.security.JwtMemberId;
 
 @RestController
@@ -36,23 +36,23 @@ public class HistoryController {
   }
 
   @GetMapping("/history/{id}/music/fail")
-  public BaseResponse<List<HistoryMusicResponse>> getTransferFailMusics(
+  public BaseResponse<List<MusicResponse>> getTransferFailMusics(
       final JwtMemberId jwtMemberId, @PathVariable final Long id
   ) {
     final var transferFailMusics = historyService.findTransferFailMusics(
         id, jwtMemberId.memberId()
     );
-    final List<HistoryMusicResponse> responses = HistoryMusicResponse
+    final List<MusicResponse> responses = MusicResponse
         .createListFromTransferFail(transferFailMusics);
     return BaseResponse.ok(responses);
   }
 
   @GetMapping("/history/{id}/music/success")
-  public BaseResponse<List<HistoryMusicResponse>> getTransferredMusics(
+  public BaseResponse<List<MusicResponse>> getTransferredMusics(
       final JwtMemberId jwtMemberId, @PathVariable final Long id
   ) {
     final var transferredMusics = historyService.findTransferredMusics(id, jwtMemberId.memberId());
-    final List<HistoryMusicResponse> responses = HistoryMusicResponse
+    final List<MusicResponse> responses = MusicResponse
         .createListFromTransferred(transferredMusics);
     return BaseResponse.ok(responses);
   }

--- a/src/main/java/play/pluv/history/domain/History.java
+++ b/src/main/java/play/pluv/history/domain/History.java
@@ -20,6 +20,7 @@ import play.pluv.base.BaseEntity;
 import play.pluv.feed.domain.Feed;
 import play.pluv.history.exception.HistoryException;
 import play.pluv.playlist.domain.MusicStreaming;
+import play.pluv.progress.domain.TransferredMusicInContext;
 
 @Entity
 @Getter
@@ -34,6 +35,7 @@ public class History extends BaseEntity {
   private Integer transferredSongCount;
   private Integer totalSongCount;
   private Long memberId;
+  private Long feedId;
   @Enumerated(EnumType.STRING)
   private MusicStreaming source;
   @Enumerated(EnumType.STRING)
@@ -42,13 +44,14 @@ public class History extends BaseEntity {
   public History(final Long id, final String title, final String thumbNailUrl,
       final Integer transferredSongCount,
       final Integer totalSongCount, final Long memberId, final MusicStreaming source,
-      final MusicStreaming destination, final LocalDateTime createdAt) {
+      final MusicStreaming destination, final LocalDateTime createdAt, final Long feedId) {
     this.id = id;
     this.title = title;
     this.thumbNailUrl = thumbNailUrl;
     this.transferredSongCount = transferredSongCount;
     this.totalSongCount = totalSongCount;
     this.memberId = memberId;
+    this.feedId = feedId;
     this.source = source;
     this.destination = destination;
     this.createdAt = createdAt;
@@ -58,7 +61,7 @@ public class History extends BaseEntity {
   @Builder
   public History(final String title, final String thumbNailUrl, final Integer transferredSongCount,
       final Integer totalSongCount, final Long memberId, final MusicStreaming source,
-      final MusicStreaming destination) {
+      final MusicStreaming destination, final Long feedId) {
     this.title = title;
     this.thumbNailUrl = thumbNailUrl;
     this.transferredSongCount = transferredSongCount;
@@ -66,33 +69,12 @@ public class History extends BaseEntity {
     this.memberId = memberId;
     this.source = source;
     this.destination = destination;
+    this.feedId = feedId;
   }
 
   public void validateOwner(final Long memberId) {
     if (!Objects.equals(memberId, this.memberId)) {
       throw new HistoryException(HISTORY_NOT_OWNER);
     }
-  }
-
-  public Feed createFeed(
-      final String creatorName, final List<TransferredMusic> transferredMusics
-  ) {
-    final String artistNames = extractArtistNames(transferredMusics);
-
-    return Feed.builder()
-        .viewable(true)
-        .historyId(id)
-        .memberId(memberId)
-        .title(title)
-        .creatorName(creatorName)
-        .artistNames(artistNames)
-        .thumbNailUrl(thumbNailUrl)
-        .build();
-  }
-
-  private String extractArtistNames(final List<TransferredMusic> transferredMusics) {
-    return transferredMusics.stream()
-        .map(TransferredMusic::getArtistNames)
-        .collect(joining(","));
   }
 }

--- a/src/main/java/play/pluv/history/domain/repository/HistoryRepository.java
+++ b/src/main/java/play/pluv/history/domain/repository/HistoryRepository.java
@@ -3,6 +3,7 @@ package play.pluv.history.domain.repository;
 import static play.pluv.history.exception.HistoryExceptionType.HISTORY_NOT_FOUND;
 
 import java.util.List;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import play.pluv.history.domain.History;
 import play.pluv.history.exception.HistoryException;
@@ -11,7 +12,14 @@ public interface HistoryRepository extends JpaRepository<History, Long> {
 
   List<History> findByMemberId(final Long memberId);
 
+  Optional<History> findByFeedId(final Long feedId);
+
   default History readById(final Long id) {
     return findById(id).orElseThrow(() -> new HistoryException(HISTORY_NOT_FOUND));
   }
+
+  default History readByFeedId(final Long feedId) {
+    return findByFeedId(feedId).orElseThrow(() -> new HistoryException(HISTORY_NOT_FOUND));
+  }
 }
+

--- a/src/main/java/play/pluv/progress/application/MusicTransferContextManager.java
+++ b/src/main/java/play/pluv/progress/application/MusicTransferContextManager.java
@@ -65,18 +65,21 @@ public class MusicTransferContextManager {
   public Long saveTransferHistory(final Long memberId) {
     final Member member = memberRepository.readById(memberId);
     final MusicTransferContext context = musicTransferContextMap.get(memberId);
-    final History history = historyRepository.save(context.toHistory());
+
+    final Feed feed = context.createFeed(member.getNickName().getNickName());
+    feedRepository.save(feed);
+
+    final History history = historyRepository.save(context.toHistory(feed.getId()));
 
     final List<TransferFailMusic> transferFailMusics = context.extractTransferFailMusics(
-        history.getId());
+        history.getId()
+    );
     transferFailMusicRepository.saveAll(transferFailMusics);
 
     final List<TransferredMusic> transferredMusics = context.extractTransferredMusics(
-        history.getId());
+        history.getId()
+    );
     transferredMusicRepository.saveAll(transferredMusics);
-
-    final Feed feed = history.createFeed(member.getNickName().getNickName(), transferredMusics);
-    feedRepository.save(feed);
 
     return history.getId();
   }

--- a/src/main/java/play/pluv/progress/domain/MusicTransferContext.java
+++ b/src/main/java/play/pluv/progress/domain/MusicTransferContext.java
@@ -1,9 +1,12 @@
 package play.pluv.progress.domain;
 
+import static java.util.stream.Collectors.joining;
+
 import java.util.ArrayList;
 import java.util.List;
 import lombok.Builder;
 import lombok.Getter;
+import play.pluv.feed.domain.Feed;
 import play.pluv.history.domain.History;
 import play.pluv.history.domain.TransferFailMusic;
 import play.pluv.history.domain.TransferredMusic;
@@ -22,7 +25,7 @@ public class MusicTransferContext {
   private final MusicStreaming destination;
   private final List<TransferredMusicInContext> transferredMusics = new ArrayList<>();
 
-  public History toHistory() {
+  public History toHistory(final Long feedId) {
     return History.builder()
         .totalSongCount(transferFailMusics.size() + transferredMusics.size())
         .transferredSongCount(transferredMusics.size())
@@ -31,6 +34,7 @@ public class MusicTransferContext {
         .destination(destination)
         .title(title)
         .memberId(memberId)
+        .feedId(feedId)
         .build();
   }
 
@@ -52,5 +56,24 @@ public class MusicTransferContext {
 
   public void addTransferredMusics(final List<TransferredMusicInContext> transferredMusics) {
     this.transferredMusics.addAll(transferredMusics);
+  }
+
+  public Feed createFeed(final String creatorName) {
+    final String artistNames = extractArtistNames(transferredMusics);
+
+    return Feed.builder()
+        .viewable(true)
+        .memberId(memberId)
+        .title(title)
+        .creatorName(creatorName)
+        .artistNames(artistNames)
+        .thumbNailUrl(thumbNailUrl)
+        .build();
+  }
+
+  private String extractArtistNames(final List<TransferredMusicInContext> transferredMusics) {
+    return transferredMusics.stream()
+        .map(TransferredMusicInContext::getArtistNames)
+        .collect(joining(","));
   }
 }

--- a/src/main/java/play/pluv/progress/domain/MusicTransferContext.java
+++ b/src/main/java/play/pluv/progress/domain/MusicTransferContext.java
@@ -62,7 +62,6 @@ public class MusicTransferContext {
     final String artistNames = extractArtistNames(transferredMusics);
 
     return Feed.builder()
-        .viewable(true)
         .memberId(memberId)
         .title(title)
         .creatorName(creatorName)

--- a/src/test/java/play/pluv/api/FeedApiTest.java
+++ b/src/test/java/play/pluv/api/FeedApiTest.java
@@ -17,6 +17,7 @@ import static org.springframework.restdocs.request.RequestDocumentation.paramete
 import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 import static play.pluv.fixture.FeedEntityFixture.피드목록;
+import static play.pluv.fixture.HistoryEntityFixture.이전한_음악들;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.restdocs.payload.ResponseFieldsSnippet;
@@ -83,6 +84,30 @@ public class FeedApiTest extends ApiTest {
                 headerWithName(AUTHORIZATION).description("pluv에서 발급한 accessToken")
             ),
             FEED_LIST_SNIPPET
+        ));
+  }
+
+  @Test
+  void 피드의_음악을_조회한다() throws Exception {
+    final Long feedId = 9L;
+    final Long historyId = 3L;
+    final var transferredMusics = 이전한_음악들(historyId);
+    when(historyService.findFeedMusics(feedId)).thenReturn(transferredMusics);
+
+    mockMvc.perform(get("/feed/{id}/music", feedId))
+        .andExpect(status().isOk())
+        .andDo(document("feed-music",
+            pathParameters(
+                parameterWithName("id").description("피드의 식별자")
+            ),
+            responseFields(
+                fieldWithPath("code").type(NUMBER).description("상태 코드"),
+                fieldWithPath("msg").type(STRING).description("상태 코드에 해당하는 메시지"),
+                fieldWithPath("data[]").type(ARRAY).description("이전한 음악들"),
+                fieldWithPath("data[].title").type(STRING).description("음악 이름"),
+                fieldWithPath("data[].imageUrl").type(STRING).description("음악 이미지 url"),
+                fieldWithPath("data[].artistNames").type(STRING).description("가수들")
+            )
         ));
   }
 }

--- a/src/test/java/play/pluv/api/FeedApiTest.java
+++ b/src/test/java/play/pluv/api/FeedApiTest.java
@@ -9,13 +9,16 @@ import static org.springframework.restdocs.headers.HeaderDocumentation.requestHe
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
 import static org.springframework.restdocs.payload.JsonFieldType.ARRAY;
+import static org.springframework.restdocs.payload.JsonFieldType.BOOLEAN;
 import static org.springframework.restdocs.payload.JsonFieldType.NUMBER;
+import static org.springframework.restdocs.payload.JsonFieldType.OBJECT;
 import static org.springframework.restdocs.payload.JsonFieldType.STRING;
 import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
 import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
 import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
 import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static play.pluv.fixture.FeedEntityFixture.피드_단건조회_값;
 import static play.pluv.fixture.FeedEntityFixture.피드목록;
 import static play.pluv.fixture.HistoryEntityFixture.이전한_음악들;
 
@@ -107,6 +110,36 @@ public class FeedApiTest extends ApiTest {
                 fieldWithPath("data[].title").type(STRING).description("음악 이름"),
                 fieldWithPath("data[].imageUrl").type(STRING).description("음악 이미지 url"),
                 fieldWithPath("data[].artistNames").type(STRING).description("가수들")
+            )
+        ));
+  }
+
+  @Test
+  void 피드를_단건_조회한다() throws Exception {
+    final Long feedId = 9L;
+    final var feedDetail = 피드_단건조회_값();
+
+    setAccessToken(token, memberId);
+    when(feedService.findFeed(feedId, memberId)).thenReturn(feedDetail);
+
+    mockMvc.perform(get("/feed/{id}", feedId)
+            .header(AUTHORIZATION, "Bearer " + token))
+        .andExpect(status().isOk())
+        .andDo(document("feed-detail",
+            pathParameters(
+                parameterWithName("id").description("피드의 식별자")
+            ),
+            responseFields(
+                fieldWithPath("code").type(NUMBER).description("상태 코드"),
+                fieldWithPath("msg").type(STRING).description("상태 코드에 해당하는 메시지"),
+                fieldWithPath("data").type(OBJECT).description("피드 단건 조회 값"),
+                fieldWithPath("data.id").type(NUMBER).description("피드 식별자"),
+                fieldWithPath("data.songCount").type(NUMBER).description("피드에 포함된 곡 수"),
+                fieldWithPath("data.title").type(STRING).description("피드 타이틀"),
+                fieldWithPath("data.imageUrl").type(STRING).description("피드 이미지 url"),
+                fieldWithPath("data.creatorName").type(STRING).description("피드 만든사람 이름"),
+                fieldWithPath("data.isBookMarked").type(BOOLEAN).description("로그인한 사용자의 저장(북마크)여부"),
+                fieldWithPath("data.createdAt").type(STRING).description("피드가 생성된날짜")
             )
         ));
   }

--- a/src/test/java/play/pluv/feed/application/FeedServiceTest.java
+++ b/src/test/java/play/pluv/feed/application/FeedServiceTest.java
@@ -8,6 +8,7 @@ import static play.pluv.fixture.MemberEntityFixture.멤버_홍혁준;
 import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import play.pluv.feed.application.dto.FeedDetailResponse;
 import play.pluv.feed.domain.Feed;
 import play.pluv.feed.domain.repository.FeedRepository;
 import play.pluv.member.domain.Member;
@@ -37,6 +38,21 @@ class FeedServiceTest extends ApplicationTest {
     assertThat(actual)
         .usingRecursiveFieldByFieldElementComparator()
         .containsExactlyInAnyOrder(savedFeed1, savedFeed2);
+  }
+
+  @Test
+  void 피드를_단건_조회한다() {
+    final Feed feed = 저장된_피드_1(feedRepository);
+
+    final FeedDetailResponse actual = feedService.findFeed(feed.getId(), 1L);
+    final FeedDetailResponse expected = new FeedDetailResponse(
+        feed.getId(), feed.getSongCount(), feed.getTitle(), feed.getThumbNailUrl(),
+        feed.getCreatorName(), false, feed.getCreatedAt().toLocalDate()
+    );
+
+    assertThat(actual)
+        .usingRecursiveComparison()
+        .isEqualTo(expected);
   }
 
   @Test

--- a/src/test/java/play/pluv/fixture/FeedEntityFixture.java
+++ b/src/test/java/play/pluv/fixture/FeedEntityFixture.java
@@ -1,6 +1,7 @@
 package play.pluv.fixture;
 
 import java.util.List;
+import play.pluv.feed.application.dto.FeedDetailResponse;
 import play.pluv.feed.domain.Feed;
 
 public class FeedEntityFixture {
@@ -19,5 +20,9 @@ public class FeedEntityFixture {
     return new Feed(
         2L, 3L, "여유로운 오후", "홍실", "가수 이름, 가수 이름, 가수 이름", "imageUrl", 10
     );
+  }
+
+  public static FeedDetailResponse 피드_단건조회_값() {
+    return FeedDetailResponse.from(피드_1(), false);
   }
 }

--- a/src/test/java/play/pluv/fixture/FeedEntityFixture.java
+++ b/src/test/java/play/pluv/fixture/FeedEntityFixture.java
@@ -11,13 +11,13 @@ public class FeedEntityFixture {
 
   private static Feed 피드_1() {
     return new Feed(
-        1L, 2L, 3L, "여유로운 오후의 어쩌구 플레이리스트", "플러버", "가수 이름, 가수 이름, 가수 이름", "imageUrl"
+        1L, 2L, "여유로운 오후의 어쩌구 플레이리스트", "플러버", "가수 이름, 가수 이름, 가수 이름", "imageUrl"
     );
   }
 
   private static Feed 피드_2() {
     return new Feed(
-        2L, 3L, 4L, "여유로운 오후", "홍실", "가수 이름, 가수 이름, 가수 이름", "imageUrl"
+        2L, 3L, "여유로운 오후", "홍실", "가수 이름, 가수 이름, 가수 이름", "imageUrl"
     );
   }
 }

--- a/src/test/java/play/pluv/fixture/FeedEntityFixture.java
+++ b/src/test/java/play/pluv/fixture/FeedEntityFixture.java
@@ -11,13 +11,13 @@ public class FeedEntityFixture {
 
   private static Feed 피드_1() {
     return new Feed(
-        1L, 2L, "여유로운 오후의 어쩌구 플레이리스트", "플러버", "가수 이름, 가수 이름, 가수 이름", "imageUrl"
+        1L, 2L, "여유로운 오후의 어쩌구 플레이리스트", "플러버", "가수 이름, 가수 이름, 가수 이름", "imageUrl", 10
     );
   }
 
   private static Feed 피드_2() {
     return new Feed(
-        2L, 3L, "여유로운 오후", "홍실", "가수 이름, 가수 이름, 가수 이름", "imageUrl"
+        2L, 3L, "여유로운 오후", "홍실", "가수 이름, 가수 이름, 가수 이름", "imageUrl", 10
     );
   }
 }

--- a/src/test/java/play/pluv/fixture/FeedFixture.java
+++ b/src/test/java/play/pluv/fixture/FeedFixture.java
@@ -7,14 +7,14 @@ public class FeedFixture {
 
   public static Feed 저장된_피드_1(final FeedRepository feedRepository) {
     final Feed feed = new Feed(
-        2L, 3L, "여유로운 오후의 어쩌구 플레이리스트", "플러버", "가수 이름, 가수 이름, 가수 이름", "imageUrl", true
+        2L, "여유로운 오후의 어쩌구 플레이리스트", "플러버", "가수 이름, 가수 이름, 가수 이름", "imageUrl"
     );
     return feedRepository.save(feed);
   }
 
   public static Feed 저장된_피드_2(final FeedRepository feedRepository) {
     final Feed feed = new Feed(
-        3L, 4L, "여유로운 오후", "홍실", "가수 이름, 가수 이름, 가수 이름", "imageUrl", true
+        3L, "여유로운 오후", "홍실", "가수 이름, 가수 이름, 가수 이름", "imageUrl"
     );
     return feedRepository.save(feed);
   }

--- a/src/test/java/play/pluv/fixture/FeedFixture.java
+++ b/src/test/java/play/pluv/fixture/FeedFixture.java
@@ -7,14 +7,14 @@ public class FeedFixture {
 
   public static Feed 저장된_피드_1(final FeedRepository feedRepository) {
     final Feed feed = new Feed(
-        2L, "여유로운 오후의 어쩌구 플레이리스트", "플러버", "가수 이름, 가수 이름, 가수 이름", "imageUrl"
+        2L, "여유로운 오후의 어쩌구 플레이리스트", "플러버", "가수 이름, 가수 이름, 가수 이름", "imageUrl", 10
     );
     return feedRepository.save(feed);
   }
 
   public static Feed 저장된_피드_2(final FeedRepository feedRepository) {
     final Feed feed = new Feed(
-        3L, "여유로운 오후", "홍실", "가수 이름, 가수 이름, 가수 이름", "imageUrl"
+        3L, "여유로운 오후", "홍실", "가수 이름, 가수 이름, 가수 이름", "imageUrl" ,10
     );
     return feedRepository.save(feed);
   }

--- a/src/test/java/play/pluv/fixture/FeedFixture.java
+++ b/src/test/java/play/pluv/fixture/FeedFixture.java
@@ -1,5 +1,6 @@
 package play.pluv.fixture;
 
+import play.pluv.feed.application.dto.FeedDetailResponse;
 import play.pluv.feed.domain.Feed;
 import play.pluv.feed.domain.repository.FeedRepository;
 
@@ -14,7 +15,7 @@ public class FeedFixture {
 
   public static Feed 저장된_피드_2(final FeedRepository feedRepository) {
     final Feed feed = new Feed(
-        3L, "여유로운 오후", "홍실", "가수 이름, 가수 이름, 가수 이름", "imageUrl" ,10
+        3L, "여유로운 오후", "홍실", "가수 이름, 가수 이름, 가수 이름", "imageUrl", 10
     );
     return feedRepository.save(feed);
   }

--- a/src/test/java/play/pluv/fixture/HistoryEntityFixture.java
+++ b/src/test/java/play/pluv/fixture/HistoryEntityFixture.java
@@ -6,6 +6,7 @@ import static play.pluv.playlist.domain.MusicStreaming.YOUTUBE;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import play.pluv.feed.application.dto.FeedDetailResponse;
 import play.pluv.history.domain.History;
 import play.pluv.history.domain.HistoryMusicId;
 import play.pluv.history.domain.TransferFailMusic;
@@ -44,4 +45,5 @@ public class HistoryEntityFixture {
             new HistoryMusicId(SPOTIFY, "cd"))
     );
   }
+
 }

--- a/src/test/java/play/pluv/fixture/HistoryEntityFixture.java
+++ b/src/test/java/play/pluv/fixture/HistoryEntityFixture.java
@@ -15,13 +15,13 @@ public class HistoryEntityFixture {
 
   public static History 히스토리_1(final Long memberId) {
     return new History(
-        1L, "히스토리 1", "thumbNailurl", 7, 10, memberId, SPOTIFY, YOUTUBE, LocalDateTime.now()
+        1L, "히스토리 1", "thumbNailurl", 7, 10, memberId, SPOTIFY, YOUTUBE, LocalDateTime.now(), 3L
     );
   }
 
   public static History 히스토리_2(final Long memberId) {
     return new History(
-        1L, "히스토리 2", "thumbNailurl", 10, 10, memberId, APPLE, SPOTIFY, LocalDateTime.now()
+        1L, "히스토리 2", "thumbNailurl", 10, 10, memberId, APPLE, SPOTIFY, LocalDateTime.now(), 3L
     );
   }
 

--- a/src/test/java/play/pluv/history/application/HistoryServiceTest.java
+++ b/src/test/java/play/pluv/history/application/HistoryServiceTest.java
@@ -107,4 +107,19 @@ class HistoryServiceTest extends ApplicationTest {
         .usingRecursiveFieldByFieldElementComparator()
         .isEqualTo(transferFailMusics);
   }
+
+  @Test
+  void 피드의_id로_이전된_음악목록을_조회한다() {
+    final Member member = 멤버_홍혁준(memberRepository);
+    final History history = 저장된_히스토리_1(historyRepository, member.getId());
+    final List<TransferredMusic> transferFailMusics = 저장된_이전한_음악들(
+        transferredMusicRepository, history.getId()
+    );
+
+    final List<TransferredMusic> actual = historyService.findFeedMusics(history.getFeedId());
+
+    assertThat(actual)
+        .usingRecursiveFieldByFieldElementComparator()
+        .isEqualTo(transferFailMusics);
+  }
 }

--- a/src/test/java/play/pluv/progress/application/MusicTransferContextManagerTest.java
+++ b/src/test/java/play/pluv/progress/application/MusicTransferContextManagerTest.java
@@ -135,14 +135,6 @@ class MusicTransferContextManagerTest extends ApplicationTest {
           .containsExactlyElementsOf(expected);
     }
 
-    @Test
-    void 히스토리를_만들경우_feed도_저장된다() {
-      final Long historyId = manager.saveTransferHistory(memberId);
-
-      assertThat(feedRepository.findByHistoryId(historyId))
-          .isNotEmpty();
-    }
-
     private List<TransferredMusic> expectedTransferredMusics(
         final List<TransferredMusicInContext> transferredMusics, final Long historyId
     ) {


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- close : #108 

## 📝 작업 내용

- 의존방향 변경
- 피드의 음악 조회 기능 추가
- 피드 단건 조회 추가

## 예상 소요 시간 및 실제 소요 시간 (일 / 시간 / 분)

예상 소요 시간 : 2시간
실제 소요 시간 : 1시간
