### PR TITLE
fix: 스포티파이 플리 이미지가 없는 경우 예외처리(#34)

### DIFF
--- a/src/main/java/play/pluv/oauth/spotify/dto/SpotifyMusic.java
+++ b/src/main/java/play/pluv/oauth/spotify/dto/SpotifyMusic.java
@@ -1,10 +1,12 @@
 package play.pluv.oauth.spotify.dto;
 
+import static play.pluv.oauth.spotify.dto.ThumbNailResponse.IMAGE_NULL_RESPONSE;
 import static play.pluv.playlist.domain.MusicStreaming.SPOTIFY;
 
 import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import java.util.List;
+import java.util.Optional;
 import play.pluv.music.domain.DestinationMusic;
 import play.pluv.music.domain.MusicId;
 
@@ -28,8 +30,9 @@ public record SpotifyMusic(
   }
 
   public String getImageUrl() {
-    //TODO: 추후 로직 수정하기 images가 nullable함
-    return album.images().get(0).url();
+    return Optional.ofNullable(album.images())
+        .map(images -> images.get(0).url())
+        .orElse(IMAGE_NULL_RESPONSE);
   }
 
   public List<String> getArtistNames() {

--- a/src/main/java/play/pluv/oauth/spotify/dto/SpotifyPlayListResponses.java
+++ b/src/main/java/play/pluv/oauth/spotify/dto/SpotifyPlayListResponses.java
@@ -1,8 +1,10 @@
 package play.pluv.oauth.spotify.dto;
 
+import static play.pluv.oauth.spotify.dto.ThumbNailResponse.IMAGE_NULL_RESPONSE;
 import static play.pluv.playlist.domain.MusicStreaming.SPOTIFY;
 
 import java.util.List;
+import java.util.Optional;
 import play.pluv.playlist.domain.PlayList;
 import play.pluv.playlist.domain.PlayListId;
 
@@ -18,10 +20,13 @@ public record SpotifyPlayListResponses(
   ) {
 
     public PlayList toPlayList() {
+      final String thumbNailUrl = Optional.ofNullable(images())
+          .map(images -> images.get(0).url())
+          .orElse(IMAGE_NULL_RESPONSE);
+
       return PlayList.builder()
           .playListId(new PlayListId(id, SPOTIFY))
-          //TODO: 추후 로직 수정하기 images가 nullable함
-          .thumbNailUrl(images.get(0).url())
+          .thumbNailUrl(thumbNailUrl)
           .songCount(tracks.total())
           .name(name)
           .build();

--- a/src/main/java/play/pluv/oauth/spotify/dto/ThumbNailResponse.java
+++ b/src/main/java/play/pluv/oauth/spotify/dto/ThumbNailResponse.java
@@ -6,4 +6,5 @@ public record ThumbNailResponse(
     String url
 ) {
 
+  static final String IMAGE_NULL_RESPONSE = "";
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- close : #34 

## 📝 작업 내용

- 이미지가 없는 경우 빈 문자열 반환,

## 예상 소요 시간 및 실제 소요 시간 (일 / 시간 / 분)

예상 소요 시간 : 1시간
실제 소요 시간 : 10분