### PR TITLE
Feature/#122 피드 아티스트 중복 제거

### DIFF
--- a/src/main/java/play/pluv/progress/domain/MusicTransferContext.java
+++ b/src/main/java/play/pluv/progress/domain/MusicTransferContext.java
@@ -1,9 +1,15 @@
 package play.pluv.progress.domain;
 
-import static java.util.stream.Collectors.joining;
+import static java.util.Comparator.comparing;
+import static java.util.function.Function.identity;
+import static java.util.stream.Collectors.counting;
+import static java.util.stream.Collectors.groupingBy;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 import lombok.Builder;
 import lombok.Getter;
 import play.pluv.feed.domain.Feed;
@@ -72,8 +78,13 @@ public class MusicTransferContext {
   }
 
   private String extractArtistNames(final List<TransferredMusicInContext> transferredMusics) {
-    return transferredMusics.stream()
+    final Map<String, Long> artistCountMap = transferredMusics.stream()
         .map(TransferredMusicInContext::getArtistNames)
-        .collect(joining(","));
+        .map(artistNames -> artistNames.split(","))
+        .flatMap(Arrays::stream)
+        .collect(groupingBy(identity(), counting()));
+    return artistCountMap.keySet().stream()
+        .sorted(comparing(artistCountMap::get).reversed())
+        .collect(Collectors.joining(","));
   }
 }

--- a/src/main/java/play/pluv/progress/domain/MusicTransferContext.java
+++ b/src/main/java/play/pluv/progress/domain/MusicTransferContext.java
@@ -80,6 +80,7 @@ public class MusicTransferContext {
   private String extractArtistNames(final List<TransferredMusicInContext> transferredMusics) {
     final Map<String, Long> artistCountMap = transferredMusics.stream()
         .map(TransferredMusicInContext::getArtistNames)
+        .filter(artistNames -> !artistNames.isBlank())
         .map(artistNames -> artistNames.split(","))
         .flatMap(Arrays::stream)
         .collect(groupingBy(identity(), counting()));

--- a/src/main/java/play/pluv/progress/domain/MusicTransferContext.java
+++ b/src/main/java/play/pluv/progress/domain/MusicTransferContext.java
@@ -67,6 +67,7 @@ public class MusicTransferContext {
         .creatorName(creatorName)
         .artistNames(artistNames)
         .thumbNailUrl(thumbNailUrl)
+        .songCount(transferredMusics.size())
         .build();
   }
 

--- a/src/test/java/play/pluv/fixture/TransferContextFixture.java
+++ b/src/test/java/play/pluv/fixture/TransferContextFixture.java
@@ -37,11 +37,11 @@ public class TransferContextFixture {
     return List.of(
         new TransferredMusicInContext(new HistoryMusicId(APPLE, "a"), "사랑하게 될거야", "한로로", "imageUrl",
             "isrc"),
-        new TransferredMusicInContext(new HistoryMusicId(APPLE, "b"), "자처", "한로로", "imageUrl",
+        new TransferredMusicInContext(new HistoryMusicId(APPLE, "b"), "자처", "한로로,창모", "imageUrl",
             "abcd"),
-        new TransferredMusicInContext(new HistoryMusicId(APPLE, "c"), "ㅈㅣㅂ", "한로로", "imageUrl",
+        new TransferredMusicInContext(new HistoryMusicId(APPLE, "c"), "ㅈㅣㅂ", "아이유", "imageUrl",
             null),
-        new TransferredMusicInContext(new HistoryMusicId(APPLE, "d"), "금붕어", "한로로", "imageUrl",
+        new TransferredMusicInContext(new HistoryMusicId(APPLE, "d"), "금붕어", "한로로,아이유", "imageUrl",
             null)
     );
   }

--- a/src/test/java/play/pluv/progress/domain/MusicTransferContextTest.java
+++ b/src/test/java/play/pluv/progress/domain/MusicTransferContextTest.java
@@ -1,0 +1,27 @@
+package play.pluv.progress.domain;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static play.pluv.fixture.TransferContextFixture.이전한_음악_목록;
+import static play.pluv.playlist.domain.MusicStreaming.APPLE;
+import static play.pluv.playlist.domain.MusicStreaming.SPOTIFY;
+
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class MusicTransferContextTest {
+
+  @Test
+  void 피드를_생성할수_있다() {
+    final List<TransferredMusicInContext> 이전한_음악_목록 = 이전한_음악_목록();
+    final MusicTransferContext context = new MusicTransferContext(
+        10L, List.of(), 10, "imageUrl", "이전 중", APPLE, SPOTIFY
+    );
+    context.addTransferredMusics(이전한_음악_목록);
+
+    final String actual = context.createFeed("creator").getArtistNames();
+    final String expected = "한로로,아이유,창모";
+
+    assertThat(actual)
+        .isEqualTo(expected);
+  }
+}

--- a/src/test/java/play/pluv/progress/domain/MusicTransferContextTest.java
+++ b/src/test/java/play/pluv/progress/domain/MusicTransferContextTest.java
@@ -4,9 +4,11 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static play.pluv.fixture.TransferContextFixture.이전한_음악_목록;
 import static play.pluv.playlist.domain.MusicStreaming.APPLE;
 import static play.pluv.playlist.domain.MusicStreaming.SPOTIFY;
+import static play.pluv.playlist.domain.MusicStreaming.YOUTUBE;
 
 import java.util.List;
 import org.junit.jupiter.api.Test;
+import play.pluv.history.domain.HistoryMusicId;
 
 class MusicTransferContextTest {
 
@@ -23,5 +25,25 @@ class MusicTransferContextTest {
 
     assertThat(actual)
         .isEqualTo(expected);
+  }
+
+  @Test
+  void 피드를_생성할떄_가수이름이없는경우() {
+    final List<TransferredMusicInContext> 이전한_음악_목록 = List.of(
+        new TransferredMusicInContext(new HistoryMusicId(YOUTUBE, "c"), "ㅈㅣㅂ", "", "imageUrl",
+            null),
+        new TransferredMusicInContext(new HistoryMusicId(YOUTUBE, "d"), "금붕어", "", "imageUrl",
+            null)
+    );
+
+    final MusicTransferContext context = new MusicTransferContext(
+        10L, List.of(), 10, "imageUrl", "이전 중", APPLE, SPOTIFY
+    );
+    context.addTransferredMusics(이전한_음악_목록);
+
+    final String actual = context.createFeed("creator").getArtistNames();
+
+    assertThat(actual)
+        .isBlank();
   }
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- close : #122 

## 📝 작업 내용

- feed SongCount 추가 안되는 오류 수정
- feed 아티스트 중복 제거
- feed의 아티스트 이름이 ,이 나오지 않도록 수정

## 예상 소요 시간 및 실제 소요 시간 (일 / 시간 / 분)

예상 소요 시간 : 1시간
실제 소요 시간 : 30분
