### PR TITLE
Feature/#117 히스토리 피드에서 이전하기

### DIFF
--- a/src/main/java/play/pluv/history/application/dto/MusicResponse.java
+++ b/src/main/java/play/pluv/history/application/dto/MusicResponse.java
@@ -7,20 +7,21 @@ import play.pluv.history.domain.TransferredMusic;
 public record MusicResponse(
     String title,
     String imageUrl,
-    String artistNames
+    String artistNames,
+    String isrcCode
 ) {
 
   public static MusicResponse from(final TransferredMusic transferredMusic) {
     return new MusicResponse(
         transferredMusic.getTitle(), transferredMusic.getImageUrl(),
-        transferredMusic.getArtistNames()
+        transferredMusic.getArtistNames(), transferredMusic.getIsrcCode()
     );
   }
 
   public static MusicResponse from(final TransferFailMusic transferFailMusic) {
     return new MusicResponse(
         transferFailMusic.getTitle(), transferFailMusic.getImageUrl(),
-        transferFailMusic.getArtistNames()
+        transferFailMusic.getArtistNames(), null
     );
   }
 

--- a/src/main/java/play/pluv/history/domain/TransferredMusic.java
+++ b/src/main/java/play/pluv/history/domain/TransferredMusic.java
@@ -28,17 +28,21 @@ public class TransferredMusic extends BaseEntity {
   private String imageUrl;
   @Getter
   private String artistNames;
+  @Getter
+  private String isrcCode;
   @Embedded
   private HistoryMusicId musicId;
 
   @Builder
-  public TransferredMusic(final Long historyId, final String title, final String imageUrl,
-      final String artistNames,
-      final HistoryMusicId musicId) {
+  public TransferredMusic(
+      final Long historyId, final String title, final String imageUrl,
+      final String artistNames, final String isrcCode, final HistoryMusicId musicId
+  ) {
     this.historyId = historyId;
     this.title = title;
     this.imageUrl = imageUrl;
     this.artistNames = artistNames;
+    this.isrcCode = isrcCode;
     this.musicId = musicId;
   }
 }

--- a/src/main/java/play/pluv/progress/domain/TransferredMusicInContext.java
+++ b/src/main/java/play/pluv/progress/domain/TransferredMusicInContext.java
@@ -22,6 +22,7 @@ public class TransferredMusicInContext {
         .imageUrl(imageUrl)
         .title(title)
         .musicId(musicId)
+        .isrcCode(isrcCode)
         .build();
   }
 }

--- a/src/test/java/play/pluv/api/FeedApiTest.java
+++ b/src/test/java/play/pluv/api/FeedApiTest.java
@@ -131,6 +131,8 @@ public class FeedApiTest extends ApiTest {
                 fieldWithPath("data[]").type(ARRAY).description("이전한 음악들"),
                 fieldWithPath("data[].title").type(STRING).description("음악 이름"),
                 fieldWithPath("data[].imageUrl").type(STRING).description("음악 이미지 url"),
+                fieldWithPath("data[].isrcCode").type(STRING).description("음악의 isrc Code")
+                    .optional(),
                 fieldWithPath("data[].artistNames").type(STRING).description("가수들")
             )
         ));

--- a/src/test/java/play/pluv/api/HistoryApiTest.java
+++ b/src/test/java/play/pluv/api/HistoryApiTest.java
@@ -122,6 +122,7 @@ public class HistoryApiTest extends ApiTest {
                 fieldWithPath("msg").type(STRING).description("상태 코드에 해당하는 메시지"),
                 fieldWithPath("data[]").type(ARRAY).description("이전하지 못한 음악들"),
                 fieldWithPath("data[].title").type(STRING).description("음악 이름"),
+                fieldWithPath("data[].isrcCode").type(STRING).description("null값").optional(),
                 fieldWithPath("data[].imageUrl").type(STRING).description("음악 이미지 url"),
                 fieldWithPath("data[].artistNames").type(STRING).description("가수들")
             )
@@ -155,6 +156,8 @@ public class HistoryApiTest extends ApiTest {
                 fieldWithPath("msg").type(STRING).description("상태 코드에 해당하는 메시지"),
                 fieldWithPath("data[]").type(ARRAY).description("이전한 음악들"),
                 fieldWithPath("data[].title").type(STRING).description("음악 이름"),
+                fieldWithPath("data[].isrcCode").type(STRING).description("음악의 isrc Code")
+                    .optional(),
                 fieldWithPath("data[].imageUrl").type(STRING).description("음악 이미지 url"),
                 fieldWithPath("data[].artistNames").type(STRING).description("가수들")
             )

--- a/src/test/java/play/pluv/fixture/HistoryEntityFixture.java
+++ b/src/test/java/play/pluv/fixture/HistoryEntityFixture.java
@@ -6,7 +6,6 @@ import static play.pluv.playlist.domain.MusicStreaming.YOUTUBE;
 
 import java.time.LocalDateTime;
 import java.util.List;
-import play.pluv.feed.application.dto.FeedDetailResponse;
 import play.pluv.history.domain.History;
 import play.pluv.history.domain.HistoryMusicId;
 import play.pluv.history.domain.TransferFailMusic;
@@ -40,9 +39,9 @@ public class HistoryEntityFixture {
   public static List<TransferredMusic> 이전한_음악들(final Long historyId) {
     return List.of(
         new TransferredMusic(historyId, "다시 사랑한다 말할까", "imagerUrl", "김동률",
-            new HistoryMusicId(SPOTIFY, "ab")),
+            "isrc", new HistoryMusicId(SPOTIFY, "ab")),
         new TransferredMusic(historyId, "오래된 노래", "imagerUrl", "김동률",
-            new HistoryMusicId(SPOTIFY, "cd"))
+            "isrc", new HistoryMusicId(SPOTIFY, "cd"))
     );
   }
 


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- close : #117 

## 📝 작업 내용

- 히스토리 음악 조회 응답값 변경
- 피드 음악 조회 응답값 변경
- TransferredMusic isrc_code column 추가

## 예상 소요 시간 및 실제 소요 시간 (일 / 시간 / 분)

예상 소요 시간 : 1시간
실제 소요 시간 : 30분
